### PR TITLE
Add basic provenance UI overlay

### DIFF
--- a/Browser Plugin/Display Headers Test/background.js
+++ b/Browser Plugin/Display Headers Test/background.js
@@ -9,6 +9,7 @@ function responseUrls(details) {
 
 chrome.webRequest.onHeadersReceived.addListener(
   responseUrls,
-  {urls: ["<all_urls>"]}
+  {urls: ["<all_urls>"]},
+  ["responseHeaders"]
 );
 

--- a/Browser Plugin/Display Headers Test/background.js
+++ b/Browser Plugin/Display Headers Test/background.js
@@ -1,12 +1,15 @@
 let responseHeaders = [];
 
+// Don't send messages to tabs before they are ready; queue them up instead
+let readyTabs = new Set();
+let unreadyQueue = new Map();
+
 function responseUrls(details) {
   if (details.type != null && details.method != null && details.requestId != null){
     responseHeaders.push(JSON.stringify(details, null, 2));
-    console.log("Saw HTTP request: " + JSON.stringify(details));		//DEBUG
+    console.log("Seesaw HTTP request: " + JSON.stringify(details));		//DEBUG
   }
-  // chrome.storage.session.set({key: responseHeaders});
-  chrome.tabs.sendMessage(details.tabId, { type: "responseHeader", details });
+  sendOrQueue(details.tabId, { type: "responseHeader", details });
 }
 
 chrome.webRequest.onHeadersReceived.addListener(
@@ -15,3 +18,36 @@ chrome.webRequest.onHeadersReceived.addListener(
   ["responseHeaders"]
 );
 
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  console.log("Received message: ", msg, " from ", sender);
+  if (msg.type === 'ready') {
+    readyTabs.add(sender.tab.id);
+    flushUnreadyQueue(sender.tab.id);
+  }
+});
+
+function sendOrQueue(tabId, msg) {
+  if (readyTabs.has(tabId)) {
+    console.log("Sending message immediately to ready tab " + tabId);
+    send(tabId, msg);
+  } else {
+    console.log("Queueing message for non-ready tab " + tabId);
+    let messages = unreadyQueue.get(tabId) ?? [];
+    messages.push(msg);
+    unreadyQueue.set(tabId, messages);
+  }
+}
+
+function flushUnreadyQueue(tabId) {
+  console.log("Flushing unready queue for newly ready tab " + tabId);
+  for (const msg of unreadyQueue.get(tabId) ?? []) {
+    console.log("Sending message to newly ready tab " + tabId);
+    send(tabId, msg);
+  }
+
+  unreadyQueue.delete(tabId);
+}
+
+function send(tabId, msg) {
+  chrome.tabs.sendMessage(tabId, msg);
+}

--- a/Browser Plugin/Display Headers Test/background.js
+++ b/Browser Plugin/Display Headers Test/background.js
@@ -5,7 +5,8 @@ function responseUrls(details) {
     responseHeaders.push(JSON.stringify(details, null, 2));
     console.log("Saw HTTP request: " + JSON.stringify(details));		//DEBUG
   }
-  chrome.storage.session.set({key: responseHeaders});
+  // chrome.storage.session.set({key: responseHeaders});
+  chrome.tabs.sendMessage(details.tabId, { type: "responseHeader", details });
 }
 
 chrome.webRequest.onHeadersReceived.addListener(

--- a/Browser Plugin/Display Headers Test/background.js
+++ b/Browser Plugin/Display Headers Test/background.js
@@ -3,6 +3,7 @@ let responseHeaders = [];
 function responseUrls(details) {
   if (details.type != null && details.method != null && details.requestId != null){
     responseHeaders.push(JSON.stringify(details, null, 2));
+    console.log("Saw HTTP request: " + JSON.stringify(details));		//DEBUG
   }
   chrome.storage.session.set({key: responseHeaders});
 }

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -1,0 +1,28 @@
+console.log("Content script running!");
+
+const responseList = document.createElement("div");
+responseList.innerHTML = "<ul></ul>";
+document.getElementsByTagName("body")[0].appendChild(responseList);
+
+chrome.runtime.onMessage.addListener((msg) => {
+    console.log("Received message: ", msg);
+    if (msg.type === 'responseHeader') {
+        handleResponseHeader(msg.details);
+    } else {
+        console.log("Ignoring provenance-free message");
+    }
+});
+
+function handleResponseHeader(responseHeader) {
+    console.log("handleResponseHeader() got: ", responseHeader);
+    const provHeader = responseHeader.responseHeaders.find((h) => h.name === 'provenance-id');
+    if (provHeader) {
+        addEntry(responseHeader.url, provHeader.value);
+    }
+}
+
+function addEntry(url, provId) {
+    const item = document.createElement("li");
+    item.innerHTML = `<b>${provId}:</b> ${url}`
+    responseList.children[0].appendChild(item);
+}

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -8,8 +8,6 @@ chrome.runtime.onMessage.addListener((msg) => {
     console.log("Received message: ", msg);
     if (msg.type === 'responseHeader') {
         handleResponseHeader(msg.details);
-    } else {
-        console.log("Ignoring provenance-free message");
     }
 });
 
@@ -18,11 +16,17 @@ function handleResponseHeader(responseHeader) {
     const provHeader = responseHeader.responseHeaders.find((h) => h.name === 'provenance-id');
     if (provHeader) {
         addEntry(responseHeader.url, provHeader.value);
+    } else {
+        console.log("Ignoring provenance-free message");
     }
 }
 
-function addEntry(url, provId) {
+function addEntry(sourceUrl, provId) {
     const item = document.createElement("li");
-    item.innerHTML = `<b>${provId}:</b> ${url}`
+    item.innerHTML = `<a href="${provenanceUrl(sourceUrl, provId)}"><b>${provId}:</b> ${sourceUrl}</a>`;
     responseList.children[0].appendChild(item);
+}
+
+function provenanceUrl(sourceUrl, provId) {
+    return (sourceUrl + "/").replace(/\/.*/, `/prov/${provId}`);
 }

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -1,13 +1,19 @@
 console.log("Content script running!");
 
-const responseList = document.createElement("div");
-responseList.style.position = 'fixed';
-responseList.style.top = '10px';
-responseList.style.left = '10px';
-responseList.style.zIndex = '1000'; // Hopefully on top of everything
-responseList.style.backgroundColor = 'green';
-responseList.innerHTML = '<span style="color: red; background-color: yellow">▶ Prov</span><ul></ul>';
-document.getElementsByTagName("body")[0].appendChild(responseList);
+const provenanceDiv = document.createElement("div");
+provenanceDiv.style.position = 'fixed';
+provenanceDiv.style.top = '10px';
+provenanceDiv.style.left = '10px';
+provenanceDiv.style.zIndex = '1000'; // Hopefully on top of everything
+provenanceDiv.style.backgroundColor = 'lightgray';
+provenanceDiv.style.padding = '10px';
+provenanceDiv.style.fontFamily = 'sans-serif';
+provenanceDiv.innerHTML = '<span style="color: red; font-weight: bold"">▶ Prov</span>';
+const provButton = provenanceDiv.children[0];
+const responseList = document.createElement("ul");
+responseList.style.display = 'none';
+provenanceDiv.appendChild(responseList);
+document.getElementsByTagName("body")[0].appendChild(provenanceDiv);
 
 chrome.runtime.onMessage.addListener((msg) => {
     console.log("Received message: ", msg);
@@ -28,13 +34,25 @@ function handleResponseHeader(responseHeader) {
 
 function addEntry(sourceUrl, provId) {
     const item = document.createElement("li");
-    item.innerHTML = `<a href="${provenanceUrl(sourceUrl, provId)}"><b>${provId}:</b> ${sourceUrl}</a>`;
-    responseList.children[0].appendChild(item);
+    item.innerHTML = `<a href="${provenanceUrl(sourceUrl, provId)}" target="_blank"><b>${provId}:</b> ${sourceUrl}</a>`;
+    responseList.appendChild(item);
 }
 
 function provenanceUrl(sourceUrl, provId) {
     return (sourceUrl + "/").replace(/\/.*/, `/prov/${provId}`);
 }
+
+function toggleProvDisplay() {
+    if (responseList.style.display === 'none') {
+        provButton.innerText = '▼ Prov';
+        responseList.style.display = 'inline';
+    } else {
+        provButton.innerText = '▶ Prov';
+        responseList.style.display = 'none';
+    }
+}
+
+provButton.onclick = toggleProvDisplay;
 
 // Let the extension know that we are ready to handle messages.
 // This is necessary to avoid a race with the main page load.

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -1,7 +1,12 @@
 console.log("Content script running!");
 
 const responseList = document.createElement("div");
-responseList.innerHTML = "<ul></ul>";
+responseList.style.position = 'fixed';
+responseList.style.top = '10px';
+responseList.style.left = '10px';
+responseList.style.zIndex = '1000'; // Hopefully on top of everything
+responseList.style.backgroundColor = 'green';
+responseList.innerHTML = '<span style="color: red; background-color: yellow">▶ Prov</span><ul></ul>';
 document.getElementsByTagName("body")[0].appendChild(responseList);
 
 chrome.runtime.onMessage.addListener((msg) => {

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -30,3 +30,9 @@ function addEntry(sourceUrl, provId) {
 function provenanceUrl(sourceUrl, provId) {
     return (sourceUrl + "/").replace(/\/.*/, `/prov/${provId}`);
 }
+
+// Let the extension know that we are ready to handle messages.
+// This is necessary to avoid a race with the main page load.
+console.log("Content script about to send ready message...");
+chrome.runtime.sendMessage({ type: "ready" });
+console.log("Content script has sent the ready message!");

--- a/Browser Plugin/Display Headers Test/manifest.json
+++ b/Browser Plugin/Display Headers Test/manifest.json
@@ -5,12 +5,12 @@
   "host_permissions": [
     "<all_urls>"
   ],
-  "action":{
+  "action": {
     "default_popup": "index.html",
     "default_title": "AJAX Detector"
   },
   "permissions": [
-    "unlimitedStorage", 
+    "unlimitedStorage",
     "storage",
     "scripting",
     "nativeMessaging",
@@ -18,10 +18,17 @@
     "activeTab",
     "tabs"
   ],
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "content.js"
+      ]
+    }
+  ],
   "background": {
     "service_worker": "background.js"
   }
 }
-
-  
-


### PR DESCRIPTION
This adds a basic UI overlay to every webpage that makes provenance information provided in `provenance-id` HTTP headers visible to users.

Initially, `▶ Prov` appears in the top-left corner of the page. Clicking it toggles between the initial "hidden" state and showing a list of all HTTP responses associated with the page that contained provenance information (a `provenance-id` HTTP header) and their (numeric) provenance bucket IDs:

![image](https://github.com/Jayman874/DOM-Instrumentation-to-Display-Provenance-Data/assets/11490991/35527370-329b-4492-8543-7085b2457b22)

Interacting with the page in a way that causes more provenance-enriched HTTP responses to be returned, e.g., by clicking a particular movie, adds entries to the list (highlighted in red):

![image](https://github.com/Jayman874/DOM-Instrumentation-to-Display-Provenance-Data/assets/11490991/bd33d868-7c00-4bd5-9839-2062c6b98798)

Clicking an entry in the list pops up a new tab showing the raw JSON fetched from the corresponding `/prov/{id}` endpoint:

![image](https://github.com/Jayman874/DOM-Instrumentation-to-Display-Provenance-Data/assets/11490991/0ac6c145-cfa8-4e0c-a456-5bdc2c66f25d)

The current UI is very basic and has several rough edges:

- Obviously the raw JSON is ugly
- When popping up a raw JSON provenance tab, *that* tab will get its own `▶ Prov` button in the top-left corner, which may even be populated by a `favicon.ico` fetch
- Initial page loads correctly include the original top-level page URL (`localhost:8080/library` in the screenshots) due to message queueing, but refreshing the page loses them.